### PR TITLE
本と日報へのコメント追加機能の実装 

### DIFF
--- a/app/controllers/books/comments_controller.rb
+++ b/app/controllers/books/comments_controller.rb
@@ -1,0 +1,7 @@
+class Books::CommentsController < ::CommentsController
+  private
+
+  def set_commentable
+    @commentable = Book.find(params[:book_id])
+  end
+end

--- a/app/controllers/books/comments_controller.rb
+++ b/app/controllers/books/comments_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Books::CommentsController < ::CommentsController
   private
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -23,7 +23,7 @@ class CommentsController < ApplicationController
   # POST /comments
   def create
     @comment = @commentable.comments.new(comment_params) do |c|
-      c.user_id = current_user.id
+      c.user = current_user
     end
 
     if @comment.save

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -16,7 +16,7 @@ class CommentsController < ApplicationController
 
   # GET /comments/1/edit
   def edit
-    @comment = Comment.find(params[:id])
+    @comment = current_user.comments.find(params[:id])
     @commentable = @comment.commentable
   end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -18,10 +18,6 @@ class CommentsController < ApplicationController
   def edit
     @comment = Comment.find(params[:id])
     @commentable = @comment.commentable
-
-    return unless @comment.user_id != current_user.id
-
-    redirect_to polymorphic_url(@comment), status: :forbidden
   end
 
   # POST /comments or /comments.json
@@ -40,11 +36,7 @@ class CommentsController < ApplicationController
 
   # PATCH/PUT /comments/1 or /comments/1.json
   def update
-    @comment = Comment.find(params[:id])
-    if @comment.user_id != current_user.id
-      redirect_to polymorphic_url(@comment), status: :forbidden
-      return
-    end
+    @comment = current_user.comments.find(params[:id])
 
     if @comment.update(comment_params)
       redirect_to comment_url(@comment), notice: t('controllers.common.notice_update', name: Comment.model_name.human)
@@ -55,12 +47,8 @@ class CommentsController < ApplicationController
 
   # DELETE /comments/1 or /comments/1.json
   def destroy
-    @comment = Comment.find(params[:id])
+    @comment = current_user.comments.find(params[:id])
     @commentable = @comment.commentable
-    if @comment.user_id != current_user.id
-      redirect_to polymorphic_url(@comment), status: :forbidden
-      return
-    end
 
     @comment.destroy
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -16,6 +16,10 @@ class CommentsController < ApplicationController
   def edit
     @comment = Comment.find(params[:id])
     @commentable = @comment.commentable
+
+    return unless @comment.user_id != current_user.id
+
+    redirect_to polymorphic_url(@comment), status: :forbidden
   end
 
   # POST /comments or /comments.json
@@ -34,6 +38,11 @@ class CommentsController < ApplicationController
   # PATCH/PUT /comments/1 or /comments/1.json
   def update
     @comment = Comment.find(params[:id])
+    if @comment.user_id != current_user.id
+      redirect_to polymorphic_url(@comment), status: :forbidden
+      return
+    end
+
     if @comment.update(comment_params)
       redirect_to comment_url(@comment), notice: 'Comment was successfully updated.'
     else
@@ -45,6 +54,11 @@ class CommentsController < ApplicationController
   def destroy
     @comment = Comment.find(params[:id])
     @commentable = @comment.commentable
+    if @comment.user_id != current_user.id
+      redirect_to polymorphic_url(@comment), status: :forbidden
+      return
+    end
+
     @comment.destroy
 
     redirect_to polymorphic_url(@commentable), notice: 'Comment was successfully destroyed.'

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CommentsController < ApplicationController
   before_action :set_commentable, only: %i[new create]
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -31,7 +31,8 @@ class CommentsController < ApplicationController
     end
 
     if @comment.save
-      redirect_to comment_url(@comment), notice: 'Comment was successfully created.'
+      redirect_to comment_url(@comment), notice: t('controllers.common.notice_create', name: Comment.model_name.human)
+
     else
       render :new, status: :unprocessable_entity
     end
@@ -46,7 +47,7 @@ class CommentsController < ApplicationController
     end
 
     if @comment.update(comment_params)
-      redirect_to comment_url(@comment), notice: 'Comment was successfully updated.'
+      redirect_to comment_url(@comment), notice: t('controllers.common.notice_update', name: Comment.model_name.human)
     else
       render :new, status: :unprocessable_entity
     end
@@ -63,7 +64,7 @@ class CommentsController < ApplicationController
 
     @comment.destroy
 
-    redirect_to polymorphic_url(@commentable), notice: 'Comment was successfully destroyed.'
+    redirect_to polymorphic_url(@commentable), notice: t('controllers.common.notice_destroy', name: Comment.model_name.human)
   end
 
   private

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,59 @@
+class CommentsController < ApplicationController
+  before_action :set_commentable, only: %i[new create]
+
+  # GET /comments/1 or /comments/1.json
+  def show
+    @comment = Comment.find(params[:id])
+    @commentable = @comment.commentable
+  end
+
+  # GET /comments/new
+  def new
+    @comment = @commentable.comments.new
+  end
+
+  # GET /comments/1/edit
+  def edit
+    @comment = Comment.find(params[:id])
+    @commentable = @comment.commentable
+  end
+
+  # POST /comments or /comments.json
+  def create
+    @comment = @commentable.comments.new(comment_params) do |c|
+      c.user_id = current_user.id
+    end
+
+    if @comment.save
+      redirect_to comment_url(@comment), notice: 'Comment was successfully created.'
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  # PATCH/PUT /comments/1 or /comments/1.json
+  def update
+    @comment = Comment.find(params[:id])
+    if @comment.update(comment_params)
+      redirect_to comment_url(@comment), notice: 'Comment was successfully updated.'
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  # DELETE /comments/1 or /comments/1.json
+  def destroy
+    @comment = Comment.find(params[:id])
+    @commentable = @comment.commentable
+    @comment.destroy
+
+    redirect_to polymorphic_url(@commentable), notice: 'Comment was successfully destroyed.'
+  end
+
+  private
+
+  # Only allow a list of trusted parameters through.
+  def comment_params
+    params.require(:comment).permit(:title, :body)
+  end
+end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -3,7 +3,7 @@
 class CommentsController < ApplicationController
   before_action :set_commentable, only: %i[new create]
 
-  # GET /comments/1 or /comments/1.json
+  # GET /comments/1
   def show
     @comment = Comment.find(params[:id])
     @commentable = @comment.commentable
@@ -20,7 +20,7 @@ class CommentsController < ApplicationController
     @commentable = @comment.commentable
   end
 
-  # POST /comments or /comments.json
+  # POST /comments
   def create
     @comment = @commentable.comments.new(comment_params) do |c|
       c.user_id = current_user.id
@@ -34,7 +34,7 @@ class CommentsController < ApplicationController
     end
   end
 
-  # PATCH/PUT /comments/1 or /comments/1.json
+  # PATCH/PUT /comments/1
   def update
     @comment = current_user.comments.find(params[:id])
 
@@ -45,7 +45,7 @@ class CommentsController < ApplicationController
     end
   end
 
-  # DELETE /comments/1 or /comments/1.json
+  # DELETE /comments/1
   def destroy
     @comment = current_user.comments.find(params[:id])
     @commentable = @comment.commentable

--- a/app/controllers/reports/comments_controller.rb
+++ b/app/controllers/reports/comments_controller.rb
@@ -1,0 +1,7 @@
+class Reports::CommentsController < ::CommentsController
+  private
+
+  def set_commentable
+    @commentable = Report.find(params[:report_id])
+  end
+end

--- a/app/controllers/reports/comments_controller.rb
+++ b/app/controllers/reports/comments_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Reports::CommentsController < ::CommentsController
   private
 

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -2,6 +2,7 @@
 
 class ReportsController < ApplicationController
   before_action :set_report, only: %i[show edit update destroy]
+  before_action :ensure_user, only: %i[edit update destroy]
 
   # GET /reports or /reports.json
   def index
@@ -21,8 +22,9 @@ class ReportsController < ApplicationController
 
   # POST /reports or /reports.json
   def create
-    @report = Report.new(report_params)
-
+    @report = Report.new(report_params) do |c|
+      c.user_id = current_user.id
+    end
     if @report.save
       redirect_to report_url(@report), notice: t('controllers.common.notice_create', name: Report.model_name.human)
     else
@@ -57,5 +59,11 @@ class ReportsController < ApplicationController
   # Only allow a list of trusted parameters through.
   def report_params
     params.require(:report).permit(:title, :body)
+  end
+
+  def ensure_user
+    return unless @report.user_id != current_user.id
+
+    redirect_to polymorphic_url(@report), status: :forbidden
   end
 end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
 class ReportsController < ApplicationController
-  before_action :set_report, only: %i[show edit]
-
   # GET /reports
   def index
     @reports = Report.order(:id).page(params[:page])
   end
 
   # GET /reports/1
-  def show; end
+  def show
+    @report = Report.find(params[:id])
+  end
 
   # GET /reports/new
   def new
@@ -17,7 +17,9 @@ class ReportsController < ApplicationController
   end
 
   # GET /reports/1/edit
-  def edit; end
+  def edit
+    @report = current_user.reports.find(params[:id])
+  end
 
   # POST /reports
   def create
@@ -49,11 +51,6 @@ class ReportsController < ApplicationController
   end
 
   private
-
-  # Use callbacks to share common setup or constraints between actions.
-  def set_report
-    @report = Report.find(params[:id])
-  end
 
   # Only allow a list of trusted parameters through.
   def report_params

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -3,12 +3,12 @@
 class ReportsController < ApplicationController
   before_action :set_report, only: %i[show edit]
 
-  # GET /reports or /reports.json
+  # GET /reports
   def index
     @reports = Report.order(:id).page(params[:page])
   end
 
-  # GET /reports/1 or /reports/1.json
+  # GET /reports/1
   def show; end
 
   # GET /reports/new
@@ -19,7 +19,7 @@ class ReportsController < ApplicationController
   # GET /reports/1/edit
   def edit; end
 
-  # POST /reports or /reports.json
+  # POST /reports
   def create
     @report = current_user.reports.new(report_params)
 
@@ -30,7 +30,7 @@ class ReportsController < ApplicationController
     end
   end
 
-  # PATCH/PUT /reports/1 or /reports/1.json
+  # PATCH/PUT /reports/1
   def update
     @report = current_user.reports.find(params[:id])
     if @report.update(report_params)
@@ -40,7 +40,7 @@ class ReportsController < ApplicationController
     end
   end
 
-  # DELETE /reports/1 or /reports/1.json
+  # DELETE /reports/1
   def destroy
     @report = current_user.reports.find(params[:id])
     @report.destroy

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+class ReportsController < ApplicationController
+  before_action :set_report, only: %i[show edit update destroy]
+
+  # GET /reports or /reports.json
+  def index
+    @reports = Report.order(:id).page(params[:page])
+  end
+
+  # GET /reports/1 or /reports/1.json
+  def show; end
+
+  # GET /reports/new
+  def new
+    @report = Report.new
+  end
+
+  # GET /reports/1/edit
+  def edit; end
+
+  # POST /reports or /reports.json
+  def create
+    @report = Report.new(report_params)
+
+    if @report.save
+      redirect_to report_url(@report), notice: t('controllers.common.notice_create', name: Report.model_name.human)
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  # PATCH/PUT /reports/1 or /reports/1.json
+  def update
+    if @report.update(report_params)
+      redirect_to report_url(@report), notice: t('controllers.common.notice_update', name: Report.model_name.human)
+      'Report was successfully updated.'
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  # DELETE /reports/1 or /reports/1.json
+  def destroy
+    @report.destroy
+
+    redirect_to reports_url, notice: 'Report was successfully destroyed.'
+  end
+
+  private
+
+  # Use callbacks to share common setup or constraints between actions.
+  def set_report
+    @report = Report.find(params[:id])
+  end
+
+  # Only allow a list of trusted parameters through.
+  def report_params
+    params.require(:report).permit(:title, :body)
+  end
+end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 class ReportsController < ApplicationController
-  before_action :set_report, only: %i[show edit update destroy]
-  before_action :ensure_user, only: %i[edit update destroy]
+  before_action :set_report, only: %i[show edit]
 
   # GET /reports or /reports.json
   def index
@@ -22,9 +21,8 @@ class ReportsController < ApplicationController
 
   # POST /reports or /reports.json
   def create
-    @report = Report.new(report_params) do |c|
-      c.user_id = current_user.id
-    end
+    @report = current_user.reports.new(report_params)
+
     if @report.save
       redirect_to report_url(@report), notice: t('controllers.common.notice_create', name: Report.model_name.human)
     else
@@ -34,9 +32,9 @@ class ReportsController < ApplicationController
 
   # PATCH/PUT /reports/1 or /reports/1.json
   def update
+    @report = current_user.reports.find(params[:id])
     if @report.update(report_params)
       redirect_to report_url(@report), notice: t('controllers.common.notice_update', name: Report.model_name.human)
-      'Report was successfully updated.'
     else
       render :edit, status: :unprocessable_entity
     end
@@ -44,6 +42,7 @@ class ReportsController < ApplicationController
 
   # DELETE /reports/1 or /reports/1.json
   def destroy
+    @report = current_user.reports.find(params[:id])
     @report.destroy
 
     redirect_to reports_url, notice: t('controllers.common.notice_destroy', name: Report.model_name.human)
@@ -59,11 +58,5 @@ class ReportsController < ApplicationController
   # Only allow a list of trusted parameters through.
   def report_params
     params.require(:report).permit(:title, :body)
-  end
-
-  def ensure_user
-    return unless @report.user_id != current_user.id
-
-    redirect_to polymorphic_url(@report), status: :forbidden
   end
 end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -46,7 +46,7 @@ class ReportsController < ApplicationController
   def destroy
     @report.destroy
 
-    redirect_to reports_url, notice: 'Report was successfully destroyed.'
+    redirect_to reports_url, notice: t('controllers.common.notice_destroy', name: Report.model_name.human)
   end
 
   private

--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+module ReportsHelper
+end

--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-module ReportsHelper
-end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -2,4 +2,5 @@
 
 class Book < ApplicationRecord
   mount_uploader :picture, PictureUploader
+  has_many :comments, as: :commentable, dependent: :destroy
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,4 @@
+class Comment < ApplicationRecord
+  belongs_to :commentable, polymorphic: true
+  belongs_to :user
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Comment < ApplicationRecord
   belongs_to :commentable, polymorphic: true
   belongs_to :user

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -2,4 +2,5 @@
 
 class Report < ApplicationRecord
   has_many :comments, as: :commentable, dependent: :destroy
+  belongs_to :user
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Report < ApplicationRecord
+end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class Report < ApplicationRecord
+  has_many :comments, as: :commentable, dependent: :destroy
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,6 @@ class User < ApplicationRecord
   has_one_attached :avatar do |attachable|
     attachable.variant :thumb, resize_to_limit: [150, 150]
   end
+
+  has_many :comments, dependent: :destroy
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,5 +8,6 @@ class User < ApplicationRecord
     attachable.variant :thumb, resize_to_limit: [150, 150]
   end
 
+  has_many :reports, dependent: :destroy
   has_many :comments, dependent: :destroy
 end

--- a/app/views/books/_form.html.erb
+++ b/app/views/books/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with(model: book) do |form| %>
   <% if book.errors.any? %>
     <div style="color: red">
-      <h2><%= t('views.common.validation_error', errors: i18n_error_count(book.errors.count), name: Book.model_name.human.downcase) %>:</h2>
+      <h2><%= t('views.common.validation_error', errors: i18n_error_count(report.errors.count), name: Report.model_name.human.downcase) %>:</h2>
 
       <ul>
         <% book.errors.each do |error| %>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -25,5 +25,5 @@
 </div>
 
 <div>
-<%= link_to "Create comment",new_book_comment_path(@book) %>
+<%= link_to t("views.common.new",name: Comment.model_name.human.downcase ),new_book_comment_path(@book) %>
 </div>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -24,7 +24,6 @@
 </div>
 </div>
 
-
 <div>
 <%= link_to "Create comment",new_book_comment_path(@book) %>
 </div>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -13,6 +13,7 @@
 
 <div>
 <div id="books" class="index-items">
+  <%= t("views.common.not_exist",name: Comment.model_name.human.downcase) if !@book.comments.exists? %>
   <% @book.comments.each do |comment| %>
     <div class="index-item">
       <%= render comment %>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -10,3 +10,21 @@
 
   <%= button_to t('views.common.destroy', name: Book.model_name.human.downcase), @book, method: :delete %>
 </nav>
+
+<div>
+<div id="books" class="index-items">
+  <% @book.comments.each do |comment| %>
+    <div class="index-item">
+      <%= render comment %>
+      <p>
+        <%= link_to t('views.common.show', name: Comment.model_name.human.downcase),book_comment_path(@book,comment) %>
+      </p>
+    </div>
+  <% end %>
+</div>
+</div>
+
+
+<div>
+<%= link_to "Create comment",new_book_comment_path(@book) %>
+</div>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,4 +1,4 @@
-<div id="<%= dom_id comment  %>">
+<div id="<%= dom_id comment %>">
   <p>
     <strong><%= Comment.human_attribute_name(:title) %>:</strong>
     <%= comment.title %>
@@ -14,7 +14,7 @@
     <%= l(comment.created_at,format: :long) %>
   </p>
   <p>
-    <strong><%= "作成者"%>:</strong>
+    <strong><%= "作成者" %>:</strong>
   <% if User.find(comment.user_id).name.empty? %>
         <%= User.find(comment.user_id).email %>
     <% else %>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -14,7 +14,7 @@
     <%= l(comment.created_at,format: :long) %>
   </p>
   <p>
-    <strong><%= "作成者" %>:</strong>
+    <strong><%= Comment.human_attribute_name(:created_by) %>:</strong>
   <% if User.find(comment.user_id).name.empty? %>
         <%= User.find(comment.user_id).email %>
     <% else %>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,0 +1,24 @@
+<div id="<%= dom_id comment  %>">
+  <p>
+    <strong><%= Comment.human_attribute_name(:title) %>:</strong>
+    <%= comment.title %>
+  </p>
+
+  <p>
+    <strong><%= Comment.human_attribute_name(:body) %>:</strong>
+    <%= comment.body %>
+  </p>
+
+  <p>
+    <strong><%= Comment.human_attribute_name(:created_at) %>:</strong>
+    <%= comment.created_at %>
+  </p>
+  <p>
+    <strong><%= "作成者"%>:</strong>
+  <% if User.find(comment.user_id).name.empty? %>
+        <%= User.find(comment.user_id).email %>
+    <% else %>
+    <% end %>
+        <%= User.find(comment.user_id).name %>
+  </p>
+</div>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -11,7 +11,7 @@
 
   <p>
     <strong><%= Comment.human_attribute_name(:created_at) %>:</strong>
-    <%= comment.created_at %>
+    <%= l(comment.created_at,format: :long) %>
   </p>
   <p>
     <strong><%= "作成者"%>:</strong>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,0 +1,14 @@
+<%= form_with(model: [@commentable,@comment]) do |form| %>
+<ul>
+      <li>
+        <%= form.label :title %>
+        <%= form.text_field :title %>
+
+        <%= form.label :body %>
+        <%= form.text_field :body %>
+      </li>
+  </ul>
+  <div>
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,13 +1,23 @@
 <%= form_with(model: [@commentable,@comment]) do |form| %>
-<ul>
-      <li>
-        <%= form.label :title %>
-        <%= form.text_field :title %>
+  <% if @comment.errors.any? %>
+    <div style="color: red">
+      <h2><%= t('views.common.validation_error', errors: i18n_error_count(book.errors.count), name: Comment.model_name.human.downcase) %>:</h2>
 
+      <ul>
+        <% @comment.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+  <div>
+        <%= form.label :title %>
+        <%= form.text_field :title,required: :true %>
+</div>
+  <div>
         <%= form.label :body %>
         <%= form.text_field :body %>
-      </li>
-  </ul>
+</div>
   <div>
     <%= form.submit %>
   </div>

--- a/app/views/comments/edit.html.erb
+++ b/app/views/comments/edit.html.erb
@@ -1,10 +1,10 @@
-<h1>Editing comment</h1>
+<h1><%= t('views.common.title_edit', name: Comment.model_name.human.downcase) %></h1>
 
 <%= render "form", comment: @comment %>
 
 <br>
 
 <div>
-  <%= link_to "Show this comment", @comment %> |
-  <%= link_to "Back to comments", polymorphic_url(@comment.commentable) %>
+  <%= link_to t('views.common.show', name: Comment.model_name.human.downcase), @comment %> 
+  <%= link_to t('views.common.back', name: Comment.model_name.human.downcase), polymorphic_url(@comment.commentable) %>
 </div>

--- a/app/views/comments/edit.html.erb
+++ b/app/views/comments/edit.html.erb
@@ -5,6 +5,6 @@
 <br>
 
 <div>
-  <%= link_to t('views.common.show', name: Comment.model_name.human.downcase), @comment %> 
+  <%= link_to t('views.common.show', name: Comment.model_name.human.downcase), @comment %>
   <%= link_to t('views.common.back', name: Comment.model_name.human.downcase), polymorphic_url(@comment.commentable) %>
 </div>

--- a/app/views/comments/edit.html.erb
+++ b/app/views/comments/edit.html.erb
@@ -1,0 +1,10 @@
+<h1>Editing comment</h1>
+
+<%= render "form", comment: @comment %>
+
+<br>
+
+<div>
+  <%= link_to "Show this comment", @comment %> |
+  <%= link_to "Back to comments", polymorphic_url(@comment.commentable) %>
+</div>

--- a/app/views/comments/new.html.erb
+++ b/app/views/comments/new.html.erb
@@ -1,4 +1,4 @@
-<h1>New comment</h1>
+<h1><%= t('views.common.title_new', name: Comment.model_name.human.downcase) %></h1>
 
 <%= render "form", comment: @comment %>
 

--- a/app/views/comments/new.html.erb
+++ b/app/views/comments/new.html.erb
@@ -1,0 +1,9 @@
+<h1>New comment</h1>
+
+<%= render "form", comment: @comment %>
+
+<br>
+
+<div>
+  <%= link_to "Back to comments", polymorphic_url(@comment.commentable) %>
+</div>

--- a/app/views/comments/new.html.erb
+++ b/app/views/comments/new.html.erb
@@ -5,5 +5,5 @@
 <br>
 
 <div>
-  <%= link_to "Back to comments", polymorphic_url(@comment.commentable) %>
+  <%= link_to t('views.common.back', name: Comment.model_name.human.downcase), polymorphic_url(@comment.commentable) %>
 </div>

--- a/app/views/comments/show.html.erb
+++ b/app/views/comments/show.html.erb
@@ -3,8 +3,12 @@
 </div>
 
 <div>
+<% if current_user.id == @comment.user_id %>
   <%= link_to t('views.common.edit', name: Comment.model_name.human.downcase), edit_report_comment_path(@comment.commentable,@comment) %>
+<% end %>
   <%= link_to t('views.common.back', name: Comment.model_name.human.downcase), polymorphic_url(@comment.commentable) %>
 
+<% if current_user.id == @comment.user_id %>
   <%= button_to t('views.common.destroy', name: Comment.model_name.human.downcase), @comment, method: :delete %>
+<% end %>
 </div>

--- a/app/views/comments/show.html.erb
+++ b/app/views/comments/show.html.erb
@@ -3,8 +3,8 @@
 </div>
 
 <div>
-  <%= link_to "Edit this comment", edit_report_comment_path(@comment.commentable,@comment) %> |
-  <%= link_to "Back to comments", polymorphic_url(@comment.commentable) %>
+  <%= link_to t('views.common.edit', name: Comment.model_name.human.downcase), edit_report_comment_path(@comment.commentable,@comment) %> 
+  <%= link_to t('views.common.back', name: Comment.model_name.human.downcase), polymorphic_url(@comment.commentable) %>
 
-  <%= button_to "Destroy this comment", @comment, method: :delete %>
+  <%= button_to t('views.common.destroy', name: Comment.model_name.human.downcase), @comment, method: :delete %>
 </div>

--- a/app/views/comments/show.html.erb
+++ b/app/views/comments/show.html.erb
@@ -3,7 +3,7 @@
 </div>
 
 <div>
-  <%= link_to t('views.common.edit', name: Comment.model_name.human.downcase), edit_report_comment_path(@comment.commentable,@comment) %> 
+  <%= link_to t('views.common.edit', name: Comment.model_name.human.downcase), edit_report_comment_path(@comment.commentable,@comment) %>
   <%= link_to t('views.common.back', name: Comment.model_name.human.downcase), polymorphic_url(@comment.commentable) %>
 
   <%= button_to t('views.common.destroy', name: Comment.model_name.human.downcase), @comment, method: :delete %>

--- a/app/views/comments/show.html.erb
+++ b/app/views/comments/show.html.erb
@@ -1,5 +1,5 @@
 <div class="show-item">
-<%= render "comments/comment",comment: @comment  %>
+<%= render "comments/comment",comment: @comment %>
 </div>
 
 <div>

--- a/app/views/comments/show.html.erb
+++ b/app/views/comments/show.html.erb
@@ -1,0 +1,10 @@
+<div class="show-item">
+<%= render "comments/comment",comment: @comment  %>
+</div>
+
+<div>
+  <%= link_to "Edit this comment", edit_report_comment_path(@comment.commentable,@comment) %> |
+  <%= link_to "Back to comments", polymorphic_url(@comment.commentable) %>
+
+  <%= button_to "Destroy this comment", @comment, method: :delete %>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,6 +21,9 @@
           <li>
             <%= link_to User.model_name.human, users_path %>
           </li>
+          <li>
+            <%= link_to Report.model_name.human, reports_path %>
+          </li>
         </ul>
         <div class="title">
           <%# html_safeを使っているが、XSSは発生しないのを確認済み %>

--- a/app/views/reports/_form.html.erb
+++ b/app/views/reports/_form.html.erb
@@ -1,10 +1,10 @@
 <%= form_with(model: report) do |form| %>
   <% if report.errors.any? %>
     <div style="color: red">
-      <h2><%= t('views.common.validation_error', errors: i18n_error_count(book.errors.count), name: Book.model_name.human.downcase) %>:</h2>
+      <h2><%= t('views.common.validation_error', errors: i18n_error_count(report.errors.count), name: Report.model_name.human.downcase) %>:</h2>
 
       <ul>
-        <% @report.errors.each do |error| %>
+        <% report.errors.each do |error| %>
           <li><%= error.full_message %></li>
         <% end %>
       </ul>

--- a/app/views/reports/_form.html.erb
+++ b/app/views/reports/_form.html.erb
@@ -4,7 +4,7 @@
       <h2><%= t('views.common.validation_error', errors: i18n_error_count(book.errors.count), name: Book.model_name.human.downcase) %>:</h2>
 
       <ul>
-        <% report.errors.each do |error| %>
+        <% @report.errors.each do |error| %>
           <li><%= error.full_message %></li>
         <% end %>
       </ul>

--- a/app/views/reports/_form.html.erb
+++ b/app/views/reports/_form.html.erb
@@ -1,0 +1,27 @@
+<%= form_with(model: report) do |form| %>
+  <% if report.errors.any? %>
+    <div style="color: red">
+      <h2><%= t('views.common.validation_error', errors: i18n_error_count(book.errors.count), name: Book.model_name.human.downcase) %>:</h2>
+
+      <ul>
+        <% report.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <%= form.label :title, style: "display: block" %>
+    <%= form.text_field :title %>
+  </div>
+
+  <div>
+    <%= form.label :body, style: "display: block" %>
+    <%= form.text_field :body %>
+  </div>
+
+  <div>
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/reports/_report.html.erb
+++ b/app/views/reports/_report.html.erb
@@ -1,0 +1,17 @@
+<div id="<%= dom_id report %>">
+  <p>
+    <strong><%= Report.human_attribute_name(:title) %>:</strong>
+    <%= report.title %>
+  </p>
+
+  <p>
+    <strong><%= Report.human_attribute_name(:body) %>:</strong>
+    <%= report.body %>
+  </p>
+
+  <p>
+    <strong><%= Report.human_attribute_name(:created_at) %>:</strong>
+    <%= report.created_at %>
+  </p>
+
+</div>

--- a/app/views/reports/edit.html.erb
+++ b/app/views/reports/edit.html.erb
@@ -1,0 +1,10 @@
+<h1><%= t('views.common.title_edit', name: Report.model_name.human.downcase) %></h1>
+
+<%= render "form", report: @report %>
+
+<br>
+
+<nav class="page-nav">
+  <%= link_to t('views.common.show', name: Report.model_name.human.downcase), @report %> |
+  <%= link_to t('views.common.back', name: i18n_pluralize(Report.model_name.human.downcase)), reports_path %>
+</nav>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -1,0 +1,18 @@
+<h1><%= t('views.common.title_index', name: i18n_pluralize(Report.model_name.human)) %></h1>
+
+<div id="reports" class="index-items">
+  <% @reports.each do |report| %>
+    <div class="index-item">
+    <%= render report %>
+    <p>
+        <%= link_to t('views.common.show', name: Report.model_name.human.downcase), report %>
+    </p>
+    </div>
+  <% end %>
+</div>
+
+<%= paginate @reports %>
+
+<nav class="page-nav">
+    <%= link_to t('views.common.new', name: Report.model_name.human.downcase), new_report_path %>
+</nav>

--- a/app/views/reports/new.html.erb
+++ b/app/views/reports/new.html.erb
@@ -1,0 +1,9 @@
+<h1><%= t('views.common.title_new', name: Report.model_name.human.downcase) %></h1>
+
+<%= render "form", report: @report %>
+
+<br>
+
+<nav class="page-nav">
+  <%= link_to t('views.common.back', name: i18n_pluralize(Report.model_name.human.downcase)), reports_path %>
+</nav>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -8,3 +8,22 @@
 
   <%= button_to t('views.common.destroy', name: Report.model_name.human.downcase), @report, method: :delete %>
 </div>
+
+
+<div>
+<div id="books" class="index-items">
+  <% @report.comments.each do |comment| %>
+    <div class="index-item">
+      <%= render comment %>
+      <p>
+        <%= link_to t('views.common.show', name: Comment.model_name.human.downcase),report_comment_path(@report,comment) %>
+      </p>
+    </div>
+  <% end %>
+</div>
+</div>
+
+
+<div>
+<%= link_to "Create comment",new_report_comment_path(@report) %>
+</div>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -15,6 +15,7 @@
 
 <div>
 <div id="books" class="index-items">
+  <%= t("views.common.not_exist",name: Comment.model_name.human.downcase) if !@report.comments.exists? %>
   <% @report.comments.each do |comment| %>
     <div class="index-item">
       <%= render comment %>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -15,7 +15,7 @@
 
 <div>
 <div id="books" class="index-items">
-  <%= t("views.common.not_exist",name: Comment.model_name.human.downcase) if !@report.comments.exists? %>
+  <%= t("views.common.not_exist",items: Comment.model_name.human.downcase) if !@report.comments.exists? %>
   <% @report.comments.each do |comment| %>
     <div class="index-item">
       <%= render comment %>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -9,7 +9,6 @@
   <%= button_to t('views.common.destroy', name: Report.model_name.human.downcase), @report, method: :delete %>
 </div>
 
-
 <div>
 <div id="books" class="index-items">
   <% @report.comments.each do |comment| %>
@@ -22,7 +21,6 @@
   <% end %>
 </div>
 </div>
-
 
 <div>
 <%= link_to "Create comment",new_report_comment_path(@report) %>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -3,10 +3,14 @@
 </div>
 
 <div>
+<% if current_user.id == @report.user_id %>
   <%= link_to t('views.common.edit', name: Report.model_name.human.downcase), edit_report_path(@report) %> |
+<% end %>
   <%= link_to t('views.common.back', name: i18n_pluralize(Report.model_name.human.downcase)), reports_path %>
 
+<% if current_user.id == @report.user_id %>
   <%= button_to t('views.common.destroy', name: Report.model_name.human.downcase), @report, method: :delete %>
+<% end %>
 </div>
 
 <div>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -27,5 +27,5 @@
 </div>
 
 <div>
-<%= link_to t("views.common.new",name: Comment.model_name.human.downcase ),new_book_comment_path(@report) %>
+<%= link_to t("views.common.new",name: Comment.model_name.human.downcase ),new_report_comment_path(@report) %>
 </div>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -1,0 +1,10 @@
+<div class="show-item">
+<%= render @report %>
+</div>
+
+<div>
+  <%= link_to t('views.common.edit', name: Report.model_name.human.downcase), edit_report_path(@report) %> |
+  <%= link_to t('views.common.back', name: i18n_pluralize(Report.model_name.human.downcase)), reports_path %>
+
+  <%= button_to t('views.common.destroy', name: Report.model_name.human.downcase), @report, method: :delete %>
+</div>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -23,5 +23,5 @@
 </div>
 
 <div>
-<%= link_to "Create comment",new_report_comment_path(@report) %>
+<%= link_to t("views.common.new",name: Comment.model_name.human.downcase ),new_book_comment_path(@report) %>
 </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,6 @@
-require_relative "boot"
+require_relative 'boot'
 
-require "rails/all"
+require 'rails/all'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -16,7 +16,7 @@ module BooksApp
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = 'Asia/Tokyo'
     # config.eager_load_paths << Rails.root.join("extras")
   end
 end

--- a/config/locales/translation_en.yml
+++ b/config/locales/translation_en.yml
@@ -3,9 +3,29 @@ en:
     models:
       book: Book
       report: Report
+      comment: Comment
+
     attributes:
       book:
         author: Author
         memo: Memo
         picture: Picture
         title: Title
+      user:
+        name: Name
+        postal_code: Postal code
+        address: Address
+        self_introduction: self_introduction 
+        avatar: Avatar
+      report:
+        title: Title
+        body: Body
+        created_at: Created at
+      comment:
+        title: Title
+        body: Body
+        created_at: Created at
+        created_by: Poster
+  views:
+    common:
+       not_exist: "There are no {itmes}."

--- a/config/locales/translation_en.yml
+++ b/config/locales/translation_en.yml
@@ -2,8 +2,7 @@ en:
   activerecord:
     models:
       book: Book
-      report: Book
-      book: Book
+      report: Report
     attributes:
       book:
         author: Author

--- a/config/locales/translation_en.yml
+++ b/config/locales/translation_en.yml
@@ -2,7 +2,8 @@ en:
   activerecord:
     models:
       book: Book
-
+      report: Book
+      book: Book
     attributes:
       book:
         author: Author

--- a/config/locales/translation_ja.yml
+++ b/config/locales/translation_ja.yml
@@ -4,6 +4,7 @@ ja:
       book: 本
       user: ユーザ
       report: 日報
+      comment: コメント
       
     attributes:
       book:
@@ -21,3 +22,8 @@ ja:
         title: タイトル
         body: 本文
         created_at: 投稿日時
+      comment:
+        title: タイトル
+        body: 本文
+        created_at: 投稿日時
+        created_by: 作成者

--- a/config/locales/translation_ja.yml
+++ b/config/locales/translation_ja.yml
@@ -27,3 +27,6 @@ ja:
         body: 本文
         created_at: 投稿日時
         created_by: 作成者
+  views:
+    common:
+       not_exist: "%{name}は１件もありません。"

--- a/config/locales/translation_ja.yml
+++ b/config/locales/translation_ja.yml
@@ -3,7 +3,8 @@ ja:
     models:
       book: 本
       user: ユーザ
-
+      report: 日報
+      
     attributes:
       book:
         author: 著者
@@ -16,3 +17,7 @@ ja:
         address: 住所
         self_introduction: 自己紹介文
         avatar: ユーザ画像
+      report:
+        title: タイトル
+        body: 本文
+        created_at: 投稿日時

--- a/config/locales/translation_ja.yml
+++ b/config/locales/translation_ja.yml
@@ -29,4 +29,4 @@ ja:
         created_by: 作成者
   views:
     common:
-       not_exist: "%{name}は１件もありません。"
+       not_exist: "%{items}は１件もありません。"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,15 @@
 Rails.application.routes.draw do
-  resources :reports
-  mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
+  mount LetterOpenerWeb::Engine, at: '/letter_opener' if Rails.env.development?
   devise_for :users
   root to: 'books#index'
-  resources :books
-  resources :users, only: %i(index show)
+
+  resources :comments
+  resources :reports do
+    resources :comments, module: 'reports'
+  end
+  resources :books do
+    resources :comments, module: 'books'
+  end
+
+  resources :users, only: %i[index show]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  resources :reports
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
   devise_for :users
   root to: 'books#index'

--- a/db/migrate/20240507110100_create_reports.rb
+++ b/db/migrate/20240507110100_create_reports.rb
@@ -3,7 +3,7 @@ class CreateReports < ActiveRecord::Migration[7.0]
     create_table :reports do |t|
       t.string :title
       t.string :body
-
+      t.references :user, foreign_key: true
       t.timestamps
     end
   end

--- a/db/migrate/20240507110100_create_reports.rb
+++ b/db/migrate/20240507110100_create_reports.rb
@@ -1,0 +1,10 @@
+class CreateReports < ActiveRecord::Migration[7.0]
+  def change
+    create_table :reports do |t|
+      t.string :title
+      t.string :body
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240512150657_create_comments.rb
+++ b/db/migrate/20240512150657_create_comments.rb
@@ -1,0 +1,11 @@
+class CreateComments < ActiveRecord::Migration[7.0]
+  def change
+    create_table :comments do |t|
+      t.string :title
+      t.text :body
+      t.references :commentable, polymorphic: true
+      t.references :user, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_02_070626) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_07_110100) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -46,6 +46,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_02_070626) do
     t.datetime "updated_at", null: false
     t.string "author"
     t.string "picture"
+  end
+
+  create_table "reports", force: :cascade do |t|
+    t.string "title"
+    t.string "body"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -63,8 +63,10 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_12_150657) do
   create_table "reports", force: :cascade do |t|
     t.string "title"
     t.string "body"
+    t.integer "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_reports_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -86,4 +88,5 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_12_150657) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "comments", "users"
+  add_foreign_key "reports", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_07_110100) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_12_150657) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -48,6 +48,18 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_07_110100) do
     t.string "picture"
   end
 
+  create_table "comments", force: :cascade do |t|
+    t.string "title"
+    t.text "body"
+    t.string "commentable_type"
+    t.integer "commentable_id"
+    t.integer "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["commentable_type", "commentable_id"], name: "index_comments_on_commentable"
+    t.index ["user_id"], name: "index_comments_on_user_id"
+  end
+
   create_table "reports", force: :cascade do |t|
     t.string "title"
     t.string "body"
@@ -73,4 +85,5 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_07_110100) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "comments", "users"
 end


### PR DESCRIPTION
実装したもの

- 日報のCRUD。ただし編集と削除は作成者のみ
- 本と日報にコメントをつけられる。ただし編集と削除は作成者のみ
    　　- 投稿日時はcreated_atの日付を採用。ロケールを東京に設定して、日本時間で表示できるように設定。
    　　- 投稿者は作成者の氏名、氏名が登録されていない場合はメールアドレスを表示。
- 本や日報が削除されれば、その子供のコメントは削除される。ユーザーが削除された場合も同じ。
- コメントが一見もない場合のメッセージも追加
- コメントの編集ができるように設定
- コメントはタイトルが必須になるよう設定

