### PR TITLE
日報の言及機能を追加

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -21,24 +21,16 @@ class ReportsController < ApplicationController
   def create
     @report = current_user.reports.new(report_params)
 
-    if @report.save
-      if @report.update_mentions
-        redirect_to @report, notice: t('controllers.common.notice_create', name: Report.model_name.human)
-      else
-        render :new, status: :unprocessable_entity
-      end
+    if @report.save_mentions_with { @report.save! }
+      redirect_to @report, notice: t('controllers.common.notice_create', name: Report.model_name.human)
     else
       render :new, status: :unprocessable_entity
     end
   end
 
   def update
-    if @report.update(report_params)
-      if @report.update_mentions
-        redirect_to @report, notice: t('controllers.common.notice_update', name: Report.model_name.human)
-      else
-        render :new, status: :unprocessable_entity
-      end
+    if @report.save_mentions_with { @report.update!(report_params) }
+      redirect_to @report, notice: t('controllers.common.notice_update', name: Report.model_name.human)
     else
       render :edit, status: :unprocessable_entity
     end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -21,7 +21,7 @@ class ReportsController < ApplicationController
   def create
     @report = current_user.reports.new(report_params)
 
-    if @report.save_mentions_with { @report.save! }
+    if @report.save_with_mentions
       redirect_to @report, notice: t('controllers.common.notice_create', name: Report.model_name.human)
     else
       render :new, status: :unprocessable_entity
@@ -29,7 +29,8 @@ class ReportsController < ApplicationController
   end
 
   def update
-    if @report.save_mentions_with { @report.update!(report_params) }
+    @report.assign_attributes(report_params)
+    if @report.save_with_mentions
       redirect_to @report, notice: t('controllers.common.notice_update', name: Report.model_name.human)
     else
       render :edit, status: :unprocessable_entity

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -22,7 +22,11 @@ class ReportsController < ApplicationController
     @report = current_user.reports.new(report_params)
 
     if @report.save
-      redirect_to @report, notice: t('controllers.common.notice_create', name: Report.model_name.human)
+      if @report.update_mentions
+        redirect_to @report, notice: t('controllers.common.notice_create', name: Report.model_name.human)
+      else
+        render :new, status: :unprocessable_entity
+      end
     else
       render :new, status: :unprocessable_entity
     end
@@ -30,7 +34,11 @@ class ReportsController < ApplicationController
 
   def update
     if @report.update(report_params)
-      redirect_to @report, notice: t('controllers.common.notice_update', name: Report.model_name.human)
+      if @report.update_mentions
+        redirect_to @report, notice: t('controllers.common.notice_update', name: Report.model_name.human)
+      else
+        render :new, status: :unprocessable_entity
+      end
     else
       render :edit, status: :unprocessable_entity
     end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -21,29 +21,21 @@ class Report < ApplicationRecord
     created_at.to_date
   end
 
-  def mentioned_reports
-    ReportMention.where(mentioned_report: id).map { |mention| Report.find(mention.report_id) }
-  end
-
-  def mentioned_reports_ids
-    mentioned_reports.map(&:report_id)
-  end
-
-  def parse_url_in_content(content)
+  def parse_url_in_content
     r = %r{http://localhost:3000/reports/(\d+)}
     content.scan(r).flatten.map(&:to_i)
   end
 
   def update_report_mentions
-    current_urls = parse_url_in_content(content)
-    existing_urls = mentioning_report_ids
+    current_ids = parse_url_in_content
+    existing_ids = mentioning_report_ids
 
-    (current_urls - existing_urls).each do |mentioning_report_id|
+    (current_ids - existing_ids).each do |mentioning_report_id|
       mentioning_report = Report.find_by(id: mentioning_report_id)
       mentioning_reports << mentioning_report if mentioning_report
     end
 
-    (existing_urls - current_urls).each do |mentioning_report_id|
+    (existing_ids - current_ids).each do |mentioning_report_id|
       mentioning_report = Report.find_by(id: mentioning_report_id)
       mentioning_reports.delete(mentioning_report) if mentioning_report
     end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -23,7 +23,7 @@ class Report < ApplicationRecord
 
   def parse_url_in_content
     r = %r{http://localhost:3000/reports/(\d+)}
-    content.scan(r).flatten.map(&:to_i)
+    content.scan(r).flatten.map(&:to_i).uniq
   end
 
   def update_report_mentions

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -24,16 +24,16 @@ class Report < ApplicationRecord
     content.scan(r).flatten.map(&:to_i).uniq
   end
 
-  def save_mentions_with
+  def save_with_mentions
     Report.transaction do
       yield
 
       current_ids = parse_url_in_content
       existing_ids = mentioning_report_ids
 
-      reports = Report.all.index_by(&:id)
       adding_report_ids = current_ids - existing_ids
       deleting_report_ids = existing_ids - current_ids
+      reports = Report.where(id: adding_report_ids + deleting_report_ids).index_by(&:id)
 
       adding_reports = adding_report_ids.map do |mentioning_report_id|
         reports[mentioning_report_id]

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -26,8 +26,7 @@ class Report < ApplicationRecord
 
   def save_with_mentions
     Report.transaction do
-      yield
-
+      save
       current_ids = parse_url_in_content
       existing_ids = mentioning_report_ids
 

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -3,6 +3,9 @@
 class Report < ApplicationRecord
   belongs_to :user
   has_many :comments, as: :commentable, dependent: :destroy
+  has_many :report_mentions, dependent: :destroy
+  has_many :mentioning_reports, through: :report_mentions, source: :mentioned_report
+  has_many :mentioned_reports, through: :report_mentions, source: :report
 
   validates :title, presence: true
   validates :content, presence: true
@@ -13,5 +16,13 @@ class Report < ApplicationRecord
 
   def created_on
     created_at.to_date
+  end
+
+  def mentioned_reports
+    ReportMention.where(mentioned_reports: id)
+  end
+
+  def mentioned_reports_ids
+    mentioned_reports.map(&:id)
   end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -3,9 +3,10 @@
 class Report < ApplicationRecord
   belongs_to :user
   has_many :comments, as: :commentable, dependent: :destroy
-  has_many :report_mentions, dependent: :destroy
-  has_many :mentioning_reports, through: :report_mentions, source: :mentioned_report
-  has_many :mentioned_reports, through: :report_mentions, source: :report
+  has_many :mentioning_relations, class_name: 'ReportMention', dependent: :destroy, foreign_key: :mentioning_id, inverse_of: :mentioning
+  has_many :mentioning_reports, through: :mentioning_relations, source: :mentioned
+  has_many :mentioned_relations, class_name: 'ReportMention', dependent: :destroy, foreign_key: :mentioned_id, inverse_of: :mentioned
+  has_many :mentioned_reports, through: :mentioned_relations, source: :mentioning
 
   validates :title, presence: true
   validates :content, presence: true

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -26,7 +26,7 @@ class Report < ApplicationRecord
 
   def save_with_mentions
     Report.transaction do
-      save
+      save!
       current_ids = parse_url_in_content
       existing_ids = mentioning_report_ids
 

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -21,11 +21,11 @@ class Report < ApplicationRecord
   end
 
   def mentioned_reports
-    ReportMention.where(mentioned_reports: id)
+    ReportMention.where(mentioned_report: id).map { |mention| Report.find(mention.report_id) }
   end
 
   def mentioned_reports_ids
-    mentioned_reports.map(&:id)
+    mentioned_reports.map(&:report_id)
   end
 
   def parse_url_in_content(content)

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -24,8 +24,10 @@ class Report < ApplicationRecord
     content.scan(r).flatten.map(&:to_i).uniq
   end
 
-  def update_mentions
+  def save_mentions_with
     Report.transaction do
+      yield
+
       current_ids = parse_url_in_content
       existing_ids = mentioning_report_ids
 

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -38,12 +38,12 @@ class Report < ApplicationRecord
     existing_urls = mentioning_report_ids
 
     (current_urls - existing_urls).each do |mentioning_report_id|
-      mentioning_report = Report.find(mentioning_report_id)
+      mentioning_report = Report.find_by(id: mentioning_report_id)
       mentioning_reports << mentioning_report if mentioning_report
     end
 
     (existing_urls - current_urls).each do |mentioning_report_id|
-      mentioning_report = Report.find(mentioning_report_id)
+      mentioning_report = Report.find_by(id: mentioning_report_id)
       mentioning_reports.delete(mentioning_report) if mentioning_report
     end
   end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -44,5 +44,7 @@ class Report < ApplicationRecord
       end.compact
       mentioning_reports.delete(deleting_reports)
     end
+  rescue ActiveRecord::RecordInvalid
+    false
   end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -30,14 +30,18 @@ class Report < ApplicationRecord
     current_ids = parse_url_in_content
     existing_ids = mentioning_report_ids
 
-    (current_ids - existing_ids).each do |mentioning_report_id|
-      mentioning_report = Report.find_by(id: mentioning_report_id)
-      mentioning_reports << mentioning_report if mentioning_report
-    end
+    reports = Report.all.index_by(&:id)
+    adding_report_ids = current_ids - existing_ids
+    deleting_report_ids = existing_ids - current_ids
 
-    (existing_ids - current_ids).each do |mentioning_report_id|
-      mentioning_report = Report.find_by(id: mentioning_report_id)
-      mentioning_reports.delete(mentioning_report) if mentioning_report
-    end
+    adding_reports = adding_report_ids.map do |mentioning_report_id|
+      reports[mentioning_report_id]
+    end.compact
+    mentioning_reports.concat adding_reports
+
+    deleting_reports = deleting_report_ids.map do |mentioning_report_id|
+      reports[mentioning_report_id]
+    end.compact
+    mentioning_reports.delete(deleting_reports)
   end
 end

--- a/app/models/report_mention.rb
+++ b/app/models/report_mention.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class ReportMention < ApplicationRecord
+  belongs_to :report
+  belongs_to :mentioned_report, class_name: 'Report'
+
+  validates :report_id, uniqueness: { scope: :mentioned_report_id }
+end

--- a/app/models/report_mention.rb
+++ b/app/models/report_mention.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class ReportMention < ApplicationRecord
-  belongs_to :report
-  belongs_to :mentioned_report, class_name: 'Report'
+  belongs_to :mentioning, class_name: 'Report', inverse_of: :mentioning_relations
+  belongs_to :mentioned, class_name: 'Report', inverse_of: :mentioned_relations
 
-  validates :report_id, uniqueness: { scope: :mentioned_report_id }
+  validates :mentioning_id, uniqueness: { scope: :mentioned_id }
 end

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -6,6 +6,8 @@
 
 <%= render 'shared/comments', commentable: @report %>
 
+
+
 <nav class="page-nav">
   <% if @report.editable?(current_user) %>
     <%= link_to t('views.common.edit', name: Report.model_name.human.downcase), edit_report_path(@report) %> |
@@ -17,10 +19,10 @@
   <% end %>
 </nav>
 
-<div>
-  <p> <%= t Report.human_attribute_name(:mentioning_reports) %></p>
+<div> 
+  <p> <%= t Report.human_attribute_name(:mentioned_reports) %></p>
   <ul>
-  <% @report.mentioning_reports.each do |report| %>
+  <% @report.mentioned_reports.each do |report| %>
     <li>
      <%= link_to report.title,polymorphic_url(report) %>
     </li>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -16,3 +16,6 @@
     <%= button_to t('views.common.destroy', name: Report.model_name.human.downcase), @report, method: :delete %>
   <% end %>
 </nav>
+
+
+<%= render 'shared/comments', commentable: @report %>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -6,8 +6,6 @@
 
 <%= render 'shared/comments', commentable: @report %>
 
-
-
 <nav class="page-nav">
   <% if @report.editable?(current_user) %>
     <%= link_to t('views.common.edit', name: Report.model_name.human.downcase), edit_report_path(@report) %> |
@@ -19,7 +17,7 @@
   <% end %>
 </nav>
 
-<div> 
+<div>
   <p> <%= t Report.human_attribute_name(:mentioned_reports) %></p>
   <ul>
   <% @report.mentioned_reports.each do |report| %>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -17,5 +17,13 @@
   <% end %>
 </nav>
 
-
-<%= render 'shared/comments', commentable: @report %>
+<div>
+  <p> <%= t Report.human_attribute_name(:mentioning_reports) %></p>
+  <ul>
+  <% @report.mentioning_reports.each do |report| %>
+    <li>
+     <%= link_to polymorphic_url(report),polymorphic_url(report) %>
+    </li>
+  <% end %>
+    </ul>
+</div>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -22,7 +22,7 @@
   <ul>
   <% @report.mentioning_reports.each do |report| %>
     <li>
-     <%= link_to polymorphic_url(report),polymorphic_url(report) %>
+     <%= link_to report.title,polymorphic_url(report) %>
     </li>
   <% end %>
     </ul>

--- a/config/locales/translation_ja.yml
+++ b/config/locales/translation_ja.yml
@@ -23,3 +23,4 @@ ja:
         content: 内容
         user: 作成者
         created_on: 作成日
+        mentioning_reports: 参照日報

--- a/config/locales/translation_ja.yml
+++ b/config/locales/translation_ja.yml
@@ -23,4 +23,5 @@ ja:
         content: 内容
         user: 作成者
         created_on: 作成日
-        mentioning_reports: 参照日報
+        mentioning_reports: 言及先日報
+        mentioned_reports:  言及元日報

--- a/db/migrate/20240519225018_create_report_mention.rb
+++ b/db/migrate/20240519225018_create_report_mention.rb
@@ -1,10 +1,10 @@
 class CreateReportMention < ActiveRecord::Migration[7.0]
   def change
     create_table :report_mentions do |t|
-      t.references :report, null: false, foreign_key: true
-      t.references :mentioned_report, null: false, foreign_key: { to_table: :reports }
+      t.references :mentioning, null: false, foreign_key: { to_table: :reports }
+      t.references :mentioned, null: false, foreign_key: { to_table: :reports }
       t.timestamps
     end
-    add_index(:report_mentions, %i[report_id mentioned_report_id], unique: true)
+    add_index(:report_mentions, %i[mentioning_id mentioned_id], unique: true)
   end
 end

--- a/db/migrate/20240519225018_create_report_mention.rb
+++ b/db/migrate/20240519225018_create_report_mention.rb
@@ -1,0 +1,10 @@
+class CreateReportMention < ActiveRecord::Migration[7.0]
+  def change
+    create_table :report_mentions do |t|
+      t.references :report, null: false, foreign_key: true
+      t.references :mentioned_report, null: false, foreign_key: { to_table: :reports }
+      t.timestamps
+    end
+    add_index(:report_mentions, %i[report_id mentioned_report_id], unique: true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_02_082433) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_19_225018) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
-    t.integer "record_id", null: false
-    t.integer "blob_id", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
@@ -34,7 +34,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_02_082433) do
   end
 
   create_table "active_storage_variant_records", force: :cascade do |t|
-    t.integer "blob_id", null: false
+    t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
@@ -57,6 +57,16 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_02_082433) do
     t.datetime "updated_at", null: false
     t.index ["commentable_type", "commentable_id"], name: "index_comments_on_commentable"
     t.index ["user_id"], name: "index_comments_on_user_id"
+  end
+
+  create_table "report_mentions", force: :cascade do |t|
+    t.integer "report_id", null: false
+    t.integer "mentioned_report_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["mentioned_report_id"], name: "index_report_mentions_on_mentioned_report_id"
+    t.index ["report_id", "mentioned_report_id"], name: "index_report_mentions_on_report_id_and_mentioned_report_id", unique: true
+    t.index ["report_id"], name: "index_report_mentions_on_report_id"
   end
 
   create_table "reports", force: :cascade do |t|
@@ -87,5 +97,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_02_082433) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "comments", "users"
+  add_foreign_key "report_mentions", "reports"
+  add_foreign_key "report_mentions", "reports", column: "mentioned_report_id"
   add_foreign_key "reports", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -60,13 +60,13 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_19_225018) do
   end
 
   create_table "report_mentions", force: :cascade do |t|
-    t.integer "report_id", null: false
-    t.integer "mentioned_report_id", null: false
+    t.integer "mentioning_id", null: false
+    t.integer "mentioned_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["mentioned_report_id"], name: "index_report_mentions_on_mentioned_report_id"
-    t.index ["report_id", "mentioned_report_id"], name: "index_report_mentions_on_report_id_and_mentioned_report_id", unique: true
-    t.index ["report_id"], name: "index_report_mentions_on_report_id"
+    t.index ["mentioned_id"], name: "index_report_mentions_on_mentioned_id"
+    t.index ["mentioning_id", "mentioned_id"], name: "index_report_mentions_on_mentioning_id_and_mentioned_id", unique: true
+    t.index ["mentioning_id"], name: "index_report_mentions_on_mentioning_id"
   end
 
   create_table "reports", force: :cascade do |t|
@@ -97,7 +97,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_19_225018) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "comments", "users"
-  add_foreign_key "report_mentions", "reports"
-  add_foreign_key "report_mentions", "reports", column: "mentioned_report_id"
+  add_foreign_key "report_mentions", "reports", column: "mentioned_id"
+  add_foreign_key "report_mentions", "reports", column: "mentioning_id"
   add_foreign_key "reports", "users"
 end

--- a/test/fixtures/report_mentions.yml
+++ b/test/fixtures/report_mentions.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/report_mention_test.rb
+++ b/test/models/report_mention_test.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ReportMentionTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
言及関係をjoinテーブルで再現し、report.mentioning_reportsで言及先を、report.mentioned_reportsで言及元の日報を取得できるように設定。
また、modelのコールバック機能で言及関係を日報の編集、新規作成時にもれなく終えるように設定。

※report.mentioned_reportsで言及元を取得する実装を、なるべくmodelの関連付けで対応したかったのですが、調べても見つけられなかったので、自分で上書きしてしまいました。他に良い方法があれば教えていただきたいです。